### PR TITLE
dev : authorization admin path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-security"
 	//OAuth2 client
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	// https://mvnrepository.com/artifact/org.springframework.security/spring-security-test
+	testImplementation("org.springframework.security:spring-security-test:6.3.1")
 }
 
 tasks.named('test') {

--- a/src/main/java/ggs/srr/config/OAuth2LoginConfig.java
+++ b/src/main/java/ggs/srr/config/OAuth2LoginConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
@@ -30,25 +29,27 @@ public class OAuth2LoginConfig {
     private final CustomOauth2userService userService;
 
     @Bean
-    SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/oauth2/**").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .oauth2Login((oauth2) -> oauth2
                         .userInfoEndpoint(userInfoEndpointConfig ->
-                            userInfoEndpointConfig.userService(userService)
+                                userInfoEndpointConfig.userService(userService)
                         ));
         return http.build();
     }
 
     @Bean
-    public ClientRegistrationRepository clientRegistrationRepository(){
+    public ClientRegistrationRepository clientRegistrationRepository() {
         return new InMemoryClientRegistrationRepository(this.ftClientRegistration());
     }
 
-    private ClientRegistration ftClientRegistration(){
+    private ClientRegistration ftClientRegistration() {
 
         return ClientRegistration.withRegistrationId("42")
                 .clientId(CLIENT_ID)

--- a/src/main/java/ggs/srr/controller/admin/AdminController.java
+++ b/src/main/java/ggs/srr/controller/admin/AdminController.java
@@ -1,4 +1,4 @@
-package ggs.srr.controller.init;
+package ggs.srr.controller.admin;
 
 import ggs.srr.service.initdata.InitDataService;
 import lombok.RequiredArgsConstructor;
@@ -9,11 +9,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-public class InitDataController {
+public class AdminController {
 
     private final InitDataService initDataService;
 
-    @GetMapping("/init_data")
+    @GetMapping("/admin/test")
+    public String test() {
+        return "admin user";
+    }
+
+    @GetMapping("/admin/init_data")
     public String init(@RegisteredOAuth2AuthorizedClient("42") OAuth2AuthorizedClient client) throws InterruptedException {
         initDataService.initUserAndProjectData(client);
         return "ok";

--- a/src/test/java/ggs/srr/controller/admin/AdminControllerTest.java
+++ b/src/test/java/ggs/srr/controller/admin/AdminControllerTest.java
@@ -1,0 +1,45 @@
+package ggs.srr.controller.admin;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("일반 사용자가 /admin 으로 시작하는 url 접근시 접근 거부")
+    void giveUser_whenRequestToAdminPath_thenForbidden() throws Exception {
+
+        mockMvc.perform(get("/admin/test")
+                .with(oauth2Login()
+                        .authorities(new SimpleGrantedAuthority("ROLE_USER"))
+                )
+        ).andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("관리자는 /admin 으로 시작하는 url 접근시 접근 허용")
+    void givenAdmin_whenRequestToAdminPath_thenAccessSuccess() throws Exception {
+
+        mockMvc
+                .perform(get("/admin/test")
+                        .with(oauth2Login()
+                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                        )
+                ).andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 이 PR의 기능은 무엇인가요?

# Authorization

## Background

기존 `/init_data` end 포인트는 모두가 접근 가능한 end point 였습니다. 하지만 누구나 쉽게 해당 엔드포인트에 접근할 경우 서버 메모리에 과부하가 걸릴것으로 예상되었습니다. 따라서 해당기능은 오로지 ADMIN User만 접근 가능하도록 end point를 /admin/init_data로 변경하였습니다.

따라서 OAuth2Config.java 에서 /admin 으로 시작되는 end point 에 대해 인가 처리를 해주었고 통합 테스트 코드를 작성하였습니다.

## 통합 테스트

테스트는 총 두가지이며 각각 일반 사용자와 관리자 권한을 가진 사용자가 동일한 엔드 포인트에 접근하였을 경우 일반 사용자는 `403 forbidden`  관리자는 `200 ok` 가 반환 되는 것을 확인하였습니다.

## 추후 변경 사항

1. Add amin user

    현재 관리자 권한을 가진 사람은 아무도 없습니다. 따라서 `init_data` end point 를 호출할 경우 42 srr 팀원들은 해당 엔드 포인트에 대해 접근 가능하도록 조치할 예정입니다.

2. Refactoring initDataService

    현재 `InitDataSevice` 내부에는 오직 method 만을 통해 db 를 초기화 하고 있습니다. 해당 로직은 사용자가 로그인 할 경우 재사용될 가능성이 높습니다. 따라서 하나의 역할과 책임을 가지는 객체로 변환시킬 에정입니다.

3. Refactoring projects endpoint

    frontend 측 main page 에서 보여줄 데이터는 하나의 엔드포인트를 호출할때 모두 보내주어야 합니다. 하지만 현재 모두 분리된 상태이며 이는 DTO 로 만들어 모든 데이터를 담아 보내줄 예정입니다. 또한 `/projects/{intraId}` end point 는 서버 내부에서 로그만 찍히는 상태이기 때문에 데이터를 반환할 수 있도록 변환해야 합니다. 

4. 통합테스트

    현재 테스트 코드는 통합 테스트 코드입니다. 이는 어플리케이션 설정을 테스트에 적용시키기 위해 선택한 방법입니다. 추후 설정을 테스트에 적용할 수 있는 방법을 찾아 통합테스트에서 단위 테스트로 수정할 예정입니다.



<!-- Fixes | Part of #issue-number -->

## 제출하기 전에
- [x] 이 PR은 오타를 수정하거나 문서를 개선합니다(이 경우 다른 확인은 무시해도 됩니다).
- [x] [기여자 가이드라인](https://github.com/42Gyeongsan-side-project/reference/blob/main/CONTRIBUTING.md#create-a-pull-request)을 읽으셨나요?
      풀 리퀘스트 섹션을 읽었나요?
- [x] Github 이슈 또는 [포럼]()을 통해 논의 또는 승인되었나요? 그렇다면 링크를 추가하세요. <!-- 포럼 링크 슬랙 채널이 개설되면 대체하기 -->
- [x] 변경 사항으로 문서를 업데이트하셨나요? 여기 [문서 가이드라인](https://github.com/42Gyeongsan-side-project/reference/blob/main/CONTRIBUTING.md) 및 [주석에 대한 팁](https://github.com/42Gyeongsan-side-project/reference/blob/main/CONTRIBUTING.md)을 참조하세요.
- [x] 필요한 테스트를 새로 작성했나요?

<!-- PR은 @로 태그할 적절한 사람을 찾으면 더 빠르게 리뷰받을 수 있습니다. 만약 git blame을 사용하는 방법을 알고 있다면 그게 가장 쉬운 방법이겠지만, 그렇지 않은 경우 부디 3명 이하로 태그해주세요.

PM: @wonhyeongseo
서버: @joejaeyoung, @joonwan

-->