### PR TITLE
feat: 사용자 정보 셀프 업데이트 기능 구현

### DIFF
--- a/src/main/java/ggs/srr/domain/user/User.java
+++ b/src/main/java/ggs/srr/domain/user/User.java
@@ -70,10 +70,10 @@ public class User {
         this.updatedAt = dateTime;
     }
 
-    public void updateInformation(double level, int wallet, int correctionPoint) {
+    public void updateInformation(double level, int wallet, int collectionPoint) {
         this.level = level;
         this.wallet = wallet;
-        this.correctionPoint = correctionPoint;
+        this.correctionPoint = collectionPoint;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/ggs/srr/exception/project/ProjectErrorCode.java
+++ b/src/main/java/ggs/srr/exception/project/ProjectErrorCode.java
@@ -1,4 +1,17 @@
 package ggs.srr.exception.project;
 
-public class ProjectErrorCode {
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ProjectErrorCode {
+    NOT_FOUND_PROJECT("해당 프로젝트를 조회할 수 없습니다.", HttpStatus.BAD_REQUEST);
+
+    private String message;
+    private HttpStatus httpStatus;
+
+    ProjectErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
 }

--- a/src/main/java/ggs/srr/exception/project/ProjectErrorCode.java
+++ b/src/main/java/ggs/srr/exception/project/ProjectErrorCode.java
@@ -1,0 +1,4 @@
+package ggs.srr.exception.project;
+
+public class ProjectErrorCode {
+}

--- a/src/main/java/ggs/srr/exception/project/ProjectException.java
+++ b/src/main/java/ggs/srr/exception/project/ProjectException.java
@@ -1,7 +1,12 @@
 package ggs.srr.exception.project;
 
+import org.springframework.http.HttpStatus;
+
 public class ProjectException extends RuntimeException {
-  public ProjectException(String message) {
-    super(message);
+  private HttpStatus httpStatus;
+
+  public ProjectException(ProjectErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.httpStatus = errorCode.getHttpStatus();
   }
 }

--- a/src/main/java/ggs/srr/exception/project/ProjectException.java
+++ b/src/main/java/ggs/srr/exception/project/ProjectException.java
@@ -1,0 +1,7 @@
+package ggs.srr.exception.project;
+
+public class ProjectException extends RuntimeException {
+  public ProjectException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/ggs/srr/exception/user/UserErrorCode.java
+++ b/src/main/java/ggs/srr/exception/user/UserErrorCode.java
@@ -6,7 +6,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum UserErrorCode {
 
-    NOT_FOUND_USER("해당 사용자를 조회할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    NOT_FOUND_USER("해당 사용자를 조회할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    UPDATE_NOT_AVAILABLE("마지막 업데이트 후 12시간이 지나야 다시 업데이트할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    API_FETCH_FAILED("API 접근에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    OAUTH_TOKEN_NOT_FOUND("인증 토큰이 없습니다.", HttpStatus.BAD_REQUEST),
+    ACCESS_TOKEN_EXPIRED("인증 토큰이 만료되었습니다. 다시 로그인해주세요.", HttpStatus.BAD_REQUEST),
+    ;// 확인해봐야함
 
     private String message;
     private HttpStatus httpStatus;

--- a/src/main/java/ggs/srr/repository/projectuser/ProjectUserRepository.java
+++ b/src/main/java/ggs/srr/repository/projectuser/ProjectUserRepository.java
@@ -67,4 +67,10 @@ public class ProjectUserRepository {
         findAll().stream()
                 .forEach(projectUser -> em.remove(projectUser));
     }
+
+    public void deleteById(Long userId) {
+        em.createQuery("delete from ProjectUser pu where pu.user.id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+    }
 }

--- a/src/main/java/ggs/srr/service/client/APIClient.java
+++ b/src/main/java/ggs/srr/service/client/APIClient.java
@@ -2,12 +2,16 @@ package ggs.srr.service.client;
 
 import ggs.srr.service.client.dto.UserDto;
 import ggs.srr.service.client.dto.UserProjectResponse.UsersProjectsResponse;
+import ggs.srr.service.client.dto.UserProfileUpdate;
 import ggs.srr.service.client.dto.UsersRequest;
 
+import ggs.srr.service.user.request.UserUpdateServiceRequest;
 import java.util.List;
 
 public interface APIClient {
     List<UsersProjectsResponse> fetchUserProjectsFromFetchProject(UsersRequest usersRequest);
     List<String> fetchProjectsFromFetchProject();
     List<UserDto> fetchUsersFromTurbofetch(String code);
+
+    UserProfileUpdate fetchUserUpdatableInformation(UserUpdateServiceRequest request);
 }

--- a/src/main/java/ggs/srr/service/client/dto/ProjectDetailInfo.java
+++ b/src/main/java/ggs/srr/service/client/dto/ProjectDetailInfo.java
@@ -1,10 +1,17 @@
 package ggs.srr.service.client.dto;
 
 import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class ProjectDetailInfo {
-    private String projectName;
-    private Integer projectFinalMark;
-    private String projectStatus;
+    private final String projectName;
+    private final Integer projectFinalMark;
+    private final String projectStatus;
+
+    public ProjectDetailInfo(String projectName, Integer projectFinalMark, String projectStatus) {
+        this.projectName = projectName;
+        this.projectFinalMark = projectFinalMark;
+        this.projectStatus = projectStatus;
+    }
 }

--- a/src/main/java/ggs/srr/service/client/dto/ProjectDetailInfo.java
+++ b/src/main/java/ggs/srr/service/client/dto/ProjectDetailInfo.java
@@ -3,7 +3,7 @@ package ggs.srr.service.client.dto;
 import lombok.Data;
 
 @Data
-public class ParsingResponseDto {
+public class ProjectDetailInfo {
     private String projectName;
     private Integer projectFinalMark;
     private String projectStatus;

--- a/src/main/java/ggs/srr/service/client/dto/UserProfileUpdate.java
+++ b/src/main/java/ggs/srr/service/client/dto/UserProfileUpdate.java
@@ -1,19 +1,23 @@
 package ggs.srr.service.client.dto;
 
 import java.util.List;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
-public class UserUpdateDto {
-    private double level;
-    private int wallet;
-    private int correction_point;
-    private List<ProjectDetailInfo> projects;
+@Getter
+public class UserProfileUpdate {
+    private final double level;
+    private final int collection_point;
+    private final int wallet;
+    private final List<ProjectDetailInfo> in_progress_projects;
+    private final List<ProjectDetailInfo> finished_projects;
 
-    public UserUpdateDto(double level, int correction_point, int wallet, List<ProjectDetailInfo> projects) {
+    public UserProfileUpdate(double level, int collection_point, int wallet,
+                             List<ProjectDetailInfo> in_progress_projects,
+                             List<ProjectDetailInfo> finished_projects) {
         this.level = level;
-        this.correction_point = correction_point;
+        this.collection_point = collection_point;
         this.wallet = wallet;
-        this.projects = projects;
+        this.in_progress_projects = in_progress_projects;
+        this.finished_projects = finished_projects;
     }
 }

--- a/src/main/java/ggs/srr/service/client/dto/UserProfileUpdate.java
+++ b/src/main/java/ggs/srr/service/client/dto/UserProfileUpdate.java
@@ -1,0 +1,19 @@
+package ggs.srr.service.client.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UserUpdateDto {
+    private double level;
+    private int wallet;
+    private int correction_point;
+    private List<ProjectDetailInfo> projects;
+
+    public UserUpdateDto(double level, int correction_point, int wallet, List<ProjectDetailInfo> projects) {
+        this.level = level;
+        this.correction_point = correction_point;
+        this.wallet = wallet;
+        this.projects = projects;
+    }
+}

--- a/src/main/java/ggs/srr/service/client/dto/UserProjectResponse.java
+++ b/src/main/java/ggs/srr/service/client/dto/UserProjectResponse.java
@@ -10,6 +10,6 @@ public class UserProjectResponse {
     @Getter
     public static class UsersProjectsResponse {
         String intraId;
-        List<ParsingResponseDto> allProjectsResponse;
+        List<ProjectDetailInfo> allProjectsResponse;
     }
 }

--- a/src/main/java/ggs/srr/service/user/UserService.java
+++ b/src/main/java/ggs/srr/service/user/UserService.java
@@ -1,16 +1,27 @@
 package ggs.srr.service.user;
 
+import ggs.srr.domain.project.Project;
+import ggs.srr.domain.projectuser.ProjectUser;
+import ggs.srr.domain.projectuser.ProjectUserStatus;
 import ggs.srr.domain.user.User;
+import ggs.srr.exception.project.ProjectException;
 import ggs.srr.exception.user.UserErrorCode;
 import ggs.srr.exception.user.UserException;
+import ggs.srr.repository.project.ProjectRepository;
+import ggs.srr.repository.projectuser.ProjectUserRepository;
 import ggs.srr.repository.user.UserRepository;
 import ggs.srr.repository.user.dto.UserRankQueryDto;
+import ggs.srr.service.client.dto.ProjectDetailInfo;
+import ggs.srr.service.client.dto.UserProfileUpdate;
 import ggs.srr.service.user.request.UserInformationServiceRequest;
 import ggs.srr.service.user.request.UserRankingServiceRequest;
+import ggs.srr.service.user.request.UserUpdateServiceRequest;
 import ggs.srr.service.user.response.LevelDistributionResponse;
 import ggs.srr.service.user.response.UserFtIdAndIntraIdResponse;
 import ggs.srr.service.user.response.UserInformationResponse;
+import ggs.srr.service.user.response.UserUpdateResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,14 +30,19 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static ggs.srr.domain.projectuser.ProjectUserStatus.*;
+import static ggs.srr.exception.project.ProjectErrorCode.NOT_FOUND_PROJECT;
 import static java.util.stream.Collectors.*;
 
 @Service
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectUserRepository projectUserRepository;
 
     @Transactional
     public void save(User user) {
@@ -91,7 +107,74 @@ public class UserService {
         return findUser.getId();
     }
 
+    @Transactional
+    public UserUpdateServiceRequest getUserUpdateRequest(String requesterIntraId, Long targetUserId) {
+        User requesterUser = userRepository.findByIntraId(requesterIntraId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        if (requesterUser.getOAuth2AccessToken() == null || requesterUser.getOAuth2RefreshToken() == null) {
+            throw new UserException(UserErrorCode.OAUTH_TOKEN_NOT_FOUND);
+        }
+
+        return new UserUpdateServiceRequest(
+                requesterUser.getOAuth2AccessToken(),
+                requesterUser.getOAuth2RefreshToken(),
+                targetUser.getFtServerId()
+        );
+    }
+
+    @Transactional
+    public UserUpdateResponse updateUserProfile(Long userId, UserProfileUpdate userProfileUpdate) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND_USER));
+
+        user.updateInformation(
+                userProfileUpdate.getLevel(),
+                userProfileUpdate.getWallet(),
+                userProfileUpdate.getCollection_point()
+        );
+
+        log.info("delete user's project. userId = {}, intraId = {}",userId, user.getIntraId());
+        projectUserRepository.deleteById(userId);
+
+        updateUserProject(user, userProfileUpdate);
+
+        return new UserUpdateResponse(user, false, userProfileUpdate.getIn_progress_projects(), userProfileUpdate.getFinished_projects());
+    }
+
     private boolean isUpdatableUser(User user, LocalDateTime now) {
         return Duration.between(user.getUpdatedAt(), now).toHours() >= 12;
     }
+
+    private void updateUserProject(User user, UserProfileUpdate userProfileUpdate) {
+        List<ProjectDetailInfo> inProgressProjects = userProfileUpdate.getIn_progress_projects();
+        updateUserProjectRepository(user, inProgressProjects, IN_PROGRESS);
+
+        List<ProjectDetailInfo> finishedProjects = userProfileUpdate.getFinished_projects();
+        updateUserProjectRepository(user, finishedProjects, FINISHED);
+    }
+
+    private void updateUserProjectRepository(User user, List<ProjectDetailInfo> finishedProjects,
+                                             ProjectUserStatus projectUserStatus) {
+        for (ProjectDetailInfo finishedProject : finishedProjects) {
+            String name = finishedProject.getProjectName();
+            Integer finalMark = finishedProject.getProjectFinalMark();
+
+            Project project = projectRepository.findByName(name)
+                    .orElseThrow(() -> new ProjectException(NOT_FOUND_PROJECT));
+
+            ProjectUser projectUser = ProjectUser.builder()
+                    .user(user)
+                    .project(project)
+                    .finalMark(finalMark)
+                    .status(projectUserStatus)
+                    .build();
+
+            projectUserRepository.save(projectUser);
+        }
+    }
+
 }

--- a/src/main/java/ggs/srr/service/user/request/UserUpdateServiceRequest.java
+++ b/src/main/java/ggs/srr/service/user/request/UserUpdateServiceRequest.java
@@ -1,0 +1,16 @@
+package ggs.srr.service.user.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserUpdateServiceRequest {
+    private final String oAuth2AccessToken;
+    private final String oAuth2RefreshToken;
+    private final Long targetFtServerId;
+
+    public UserUpdateServiceRequest(String oAuth2AccessToken, String oAuth2RefreshToken, Long targetFtServerId) {
+        this.oAuth2AccessToken = oAuth2AccessToken;
+        this.oAuth2RefreshToken = oAuth2RefreshToken;
+        this.targetFtServerId = targetFtServerId;
+    }
+}

--- a/src/main/java/ggs/srr/service/user/response/UserUpdateResponse.java
+++ b/src/main/java/ggs/srr/service/user/response/UserUpdateResponse.java
@@ -1,0 +1,48 @@
+package ggs.srr.service.user.response;
+
+import ggs.srr.domain.user.User;
+import ggs.srr.service.client.dto.ProjectDetailInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "업데이트된 사용자 정보 응답")
+public class UserUpdateResponse {
+    @Schema(description = "사용자 고유 id")
+    private Long id;
+
+    @Schema(description = "사용자 intra id")
+    private String intraId;
+
+    @Schema(description = "사용자 level")
+    private double level;
+
+    @Schema(description = "사용자 알타리안 달러")
+    private int wallet;
+
+    @Schema(description = "사용자 보유 평가 포인트")
+    private int collectionPoint;
+
+    @Schema(description = "업데이트 가능여부. 최근 업데이트로 부터 12 시간이후 true 로 변경됨")
+    private boolean updatable;
+
+    @Schema(description = "진행중인 과제")
+    private List<ProjectDetailInfo> inProgressProjects;
+
+    @Schema(description = "완료한 과제")
+    private List<ProjectDetailInfo> finishedProjects;
+
+    public UserUpdateResponse(User user, boolean updatable, List<ProjectDetailInfo> inProgressProjects,
+                              List<ProjectDetailInfo> finishedProjects) {
+
+        this.id = user.getId();
+        this.intraId = user.getIntraId();
+        this.level = user.getLevel();
+        this.wallet = user.getWallet();
+        this.collectionPoint = user.getCorrectionPoint();
+        this.updatable = updatable;
+        this.inProgressProjects = inProgressProjects;
+        this.finishedProjects = finishedProjects;
+    }
+}

--- a/src/test/java/ggs/srr/repository/projectuser/ProjectUserRepositoryTest.java
+++ b/src/test/java/ggs/srr/repository/projectuser/ProjectUserRepositoryTest.java
@@ -268,6 +268,35 @@ class ProjectUserRepositoryTest {
         assertThat(all).isEmpty();
     }
 
+    @Test
+    void deleteById() {
+        User test1 = createUser("test1");
+        User test2 = createUser("test2");
+
+        Project tp1 = createProject("test1");
+        Project tp2 = createProject("test2");
+
+        ProjectUser pu1 = createProjectUser(test1, tp1, IN_PROGRESS);
+        ProjectUser pu2 = createProjectUser(test1, tp2, FINISHED);
+        ProjectUser pu3 = createProjectUser(test2, tp1, IN_PROGRESS);
+
+        userRepository.save(test1);
+        userRepository.save(test2);
+
+        projectRepository.save(tp1);
+        projectRepository.save(tp2);
+
+        projectUserRepository.save(pu1);
+        projectUserRepository.save(pu2);
+        projectUserRepository.save(pu3);
+
+        projectUserRepository.deleteById(test1.getId());
+
+        List<ProjectUser> result = projectUserRepository.findAll();
+
+        assertThat(result).hasSize(1);
+    }
+
     private User createUser(String intraId) {
         return User.builder()
                 .intraId(intraId)

--- a/src/test/java/ggs/srr/service/user/UserServiceTest.java
+++ b/src/test/java/ggs/srr/service/user/UserServiceTest.java
@@ -1,12 +1,24 @@
 package ggs.srr.service.user;
 
+import ggs.srr.domain.project.Project;
+import ggs.srr.domain.projectuser.ProjectUser;
+import ggs.srr.domain.projectuser.ProjectUserStatus;
 import ggs.srr.domain.user.User;
+import ggs.srr.exception.project.ProjectException;
+import ggs.srr.exception.user.UserErrorCode;
+import ggs.srr.exception.user.UserException;
+import ggs.srr.repository.project.ProjectRepository;
+import ggs.srr.repository.projectuser.ProjectUserRepository;
 import ggs.srr.repository.user.UserRepository;
+import ggs.srr.service.client.dto.ProjectDetailInfo;
+import ggs.srr.service.client.dto.UserProfileUpdate;
 import ggs.srr.service.user.request.UserInformationServiceRequest;
 import ggs.srr.service.user.request.UserRankingServiceRequest;
 import ggs.srr.service.user.response.LevelDistributionResponse;
 import ggs.srr.service.user.response.UserInformationResponse;
+import ggs.srr.service.user.response.UserUpdateResponse;
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +28,11 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static ggs.srr.domain.projectuser.ProjectUserStatus.FINISHED;
+import static ggs.srr.domain.projectuser.ProjectUserStatus.IN_PROGRESS;
+import static ggs.srr.exception.project.ProjectErrorCode.NOT_FOUND_PROJECT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 
 @SpringBootTest
@@ -26,6 +42,12 @@ class UserServiceTest {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @Autowired
+    ProjectUserRepository projectUserRepository;
 
     @Autowired
     UserService userService;
@@ -159,12 +181,120 @@ class UserServiceTest {
         assertThat(userLevelRanking).isSortedAccordingTo((r1, r2) -> r2.getCollectionPoint() - r1.getCollectionPoint());
     }
 
-    private User createUserBy(String intraId, double level, int wallet, int collectionPoint) {
+    @DisplayName("존재하지 않는 요청자로 업데이트 요청 준비시 예외 발생")
+    @Test
+    void getUserUpdateRequest_RequesterNotFound() {
+        // given
+        User target = createUserBy("target", 1.2, 0, 0);
+        userRepository.save(target);
+
+        // when & then
+        UserException exception = assertThrows(UserException.class, () -> {
+            userService.getUserUpdateRequest("nonexistent", target.getId());
+        });
+
+        assertThat(exception.getMessage()).isEqualTo(UserErrorCode.NOT_FOUND_USER.getMessage());
+    }
+
+    @DisplayName("존재하지 않는 대상 사용자로 업데이트 요청 준비시 예외 발생")
+    @Test
+    void getUserUpdateRequest_TargetUserNotFound() {
+        // given
+        User requester = createUserBy("requester", 1.2, 0, 0);
+        userRepository.save(requester);
+
+        // when & then
+        UserException exception = assertThrows(UserException.class, () -> {
+            userService.getUserUpdateRequest(requester.getIntraId(), 999L);
+        });
+
+        assertThat(exception.getMessage()).isEqualTo(UserErrorCode.NOT_FOUND_USER.getMessage());
+    }
+
+    @DisplayName("사용자 프로필 정보를 성공적으로 업데이트한다")
+    @Test
+    void updateUserProfile_Success() {
+        // given
+        User user = createUserBy("test", 6.5, 10, 5);
+        userRepository.save(user);
+
+        Project project1 = createProject("p1");
+        Project project2 = createProject("p2");
+        projectRepository.save(project1);
+        projectRepository.save(project2);
+
+        List<ProjectDetailInfo> inProgressProjects = new ArrayList<>();
+        inProgressProjects.add(new ProjectDetailInfo("p1", 0, "inProgress"));
+
+        List<ProjectDetailInfo> finishedProjects = new ArrayList<>();
+        finishedProjects.add(new ProjectDetailInfo("p2", 100, "finished"));
+
+        UserProfileUpdate userProfileUpdate = new UserProfileUpdate(
+                7.0, 10, 15, inProgressProjects, finishedProjects);
+
+        // when
+        UserUpdateResponse response = userService.updateUserProfile(user.getId(), userProfileUpdate);
+
+        // then
+        assertThat(user.getLevel()).isEqualTo(7.0);
+        assertThat(user.getWallet()).isEqualTo(15);
+        assertThat(user.getCorrectionPoint()).isEqualTo(10);
+
+        List<ProjectUser> inProgressProjectUsers = projectUserRepository.findByUserIdAndStatus(
+                user.getId(), IN_PROGRESS);
+        List<ProjectUser> finishedProjectUsers = projectUserRepository.findByUserIdAndStatus(
+                user.getId(), FINISHED);
+
+        assertThat(inProgressProjectUsers).hasSize(1);
+        assertThat(inProgressProjectUsers.get(0).getProject().getName()).isEqualTo("p1");
+        assertThat(inProgressProjectUsers.get(0).getFinalMark()).isEqualTo(0);
+
+        assertThat(finishedProjectUsers).hasSize(1);
+        assertThat(finishedProjectUsers.get(0).getProject().getName()).isEqualTo("p2");
+        assertThat(finishedProjectUsers.get(0).getFinalMark()).isEqualTo(100);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getLevel()).isEqualTo(7.0);
+        assertThat(response.getWallet()).isEqualTo(15);
+        assertThat(response.getCollectionPoint()).isEqualTo(10);
+        assertThat(response.isUpdatable()).isFalse();
+        assertThat(response.getInProgressProjects()).hasSize(1);
+        assertThat(response.getFinishedProjects()).hasSize(1);
+    }
+
+    @DisplayName("존재하지 않는 프로젝트로 사용자 프로필 업데이트 시 예외 발생")
+    @Test
+    void updateUserProfile_ProjectNotFound() {
+        // given
+        User user = createUserBy("test", 6.5, 10, 5);
+        userRepository.save(user);
+
+        List<ProjectDetailInfo> inProgressProjects = new ArrayList<>();
+        inProgressProjects.add(new ProjectDetailInfo("nonexistent", 0,"in_progress"));
+
+        UserProfileUpdate userProfileUpdate = new UserProfileUpdate(
+                7.0, 150, 10, inProgressProjects, new ArrayList<>());
+
+        // when & then
+        ProjectException exception = assertThrows(ProjectException.class, () -> {
+            userService.updateUserProfile(user.getId(), userProfileUpdate);
+        });
+
+        assertThat(exception.getMessage()).isEqualTo(NOT_FOUND_PROJECT.getMessage());
+    }
+
+        private User createUserBy(String intraId, double level, int wallet, int collectionPoint) {
         return User.builder()
                 .intraId(intraId)
                 .level(level)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private Project createProject(String projectName) {
+        return Project.builder()
+                .name(projectName)
                 .build();
     }
 }


### PR DESCRIPTION
## 작업 내용
사용자가 본인의 개인 정보를 직접 업데이트할 수 있는 기능을 구현했습니다.

### 구현 사항 

**1. 사용자 정보 update API 추가**

- PATCH /api/users/{userId} 엔드포인트 구현
- 12시간마다 1번 업데이트 가능하도록 제한
- 업데이트 가능 항목: 레벨, 알타리안 달러, 평가 포인트, 진행중인 과제, 완료한 과제

**2. 42API 통신**

- 사용자 최신 정보를 42 API에서 가져오는 로직 구현
- OAuth2 토큰을 활용한 인증 처리
- 레벨, 알타리안 달러, 평가 포인트 정보 파싱
- 프로젝트 정보 조회 및 상태별 분류 (진행중/완료)

**3. database update**

- User의 정보 업데이트 - level, wallet, correction_point
- ProjectUser 정보 업데이트 - in_progress_project, finished_project

**4. 응답 형식 개선**

- 업데이트된 사용자 정보와 함께 진행중/완료된 프로젝트 정보를 반환
- 프로젝트별 상세 정보 포함 (이름, 점수)

### 테스트

**1. 컨트롤러 테스트**

- UserControllerTest: 업데이트 엔드포인트 정상 동작 테스트


**2. 서비스 테스트**

- UserServiceTest: 비즈니스 로직 테스트
- 업데이트 가능 여부 검증 테스트
- 예외 상황 처리 테스트

### 주요 변경 사항

- UserController: updateUserInformation() 메서드 추가
- UserService: 업데이트 관련 메서드 추가
  - getUserUpdateRequest(): 업데이트 요청 준비
  - updateUserProfile(): 실제 업데이트 수행


- APIClientImpl: 42 API 통신 로직 구현
  - fetchUserUpdateData(): 최신 데이터 조회


- 새로운 DTO 클래스 추가
  - UserProfileUpdate: API에서 받은 업데이트 데이터
  - UserUpdateResponse: 업데이트 결과 응답
  - ProjectDetailInfo: 프로젝트 상세 정보


### 데이터 흐름

```
1. 사용자 업데이트 요청 (PATCH /api/users/{userId})
2. 업데이트 가능 여부 확인 (12시간 경과 체크)
3. 요청자의 OAuth 토큰으로 42 API 호출
4. 최신 사용자 정보 및 프로젝트 정보 조회
5. 데이터베이스 업데이트 (User, Project, ProjectUser)
6. 업데이트된 정보 응답 반환
```

## 검토해야할 부분

1. refreshToken을 통해 Token을 재발급 받아 실행하도록 리팩토링 진행되어야 합니다.
2. 진행중인 프로젝트와 완료된 프로젝트가 나뉘어 UserProfileUpdate에 담겨 있지만 하나의 List로 합쳐 status를 나누어 저장하도록 리팩토링 진행되어야 할 것 같습니다.
3. 중복되는 로직을 통일할 수 있게 리팩토링 진행해야할 것 같습니다.

이외의 추후 변경되어야 할 사항이 있다면 코멘트 달아주시면 감사하겠습니다.

---

**검토 대상자**
@joejaeyoung @joonwan @eaststar113 


<!-- PR은 @로 태그할 적절한 사람을 찾으면 더 빠르게 리뷰받을 수 있습니다. 만약 git blame을 사용하는 방법을 알고 있다면 그게 가장 쉬운 방법이겠지만, 그렇지 않은 경우 부디 3명 이하로 태그해주세요.

PM: @wonhyeongseo
서버: @joejaeyoung, @joonwan
프론트엔드: @ghkgus, @eaststar113, @Bebsae-Utae
iOS: @DonsNote, @devoogie
-->